### PR TITLE
ApiResult and ApiError

### DIFF
--- a/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/ApiError.java
+++ b/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/ApiError.java
@@ -1,0 +1,25 @@
+package com.minhojang.ilikethispagebackend.api;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiError {
+  private final String message;
+  private final int status;
+
+  ApiError(Throwable throwable, HttpStatus status) {
+    this(throwable.getMessage(), status);
+  }
+
+  ApiError(String message, HttpStatus status) {
+    this.message = message;
+    this.status = status.value();
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+}

--- a/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/ApiResult.java
+++ b/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/ApiResult.java
@@ -1,0 +1,39 @@
+package com.minhojang.ilikethispagebackend.api;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiResult<T> {
+  private final boolean success;
+  private final T response;
+  private final ApiError error;
+
+  public static <T> ApiResult<T> success(T response) {
+    return new ApiResult<>(true, response, null);
+  }
+
+  public static ApiResult<?> error(Throwable throwable, HttpStatus status) {
+    return new ApiResult<>(false, null, new ApiError(throwable, status));
+  }
+
+  public static ApiResult<?> error(String message, HttpStatus status) {
+    return new ApiResult<>(false, null, new ApiError(message, status));
+  }
+
+  private ApiResult(boolean success, T response, ApiError error) {
+    this.success = success;
+    this.response = response;
+    this.error = error;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public T getResponse() {
+    return response;
+  }
+
+  public ApiError getError() {
+    return error;
+  }
+}


### PR DESCRIPTION
컨트롤러에서 API 호출 결과를 보낼 때, 정상적인 응답을 반환하거나 에러를 반환할 수 있다. 그에 따라 API 호출 결과를 감쌀 수 있는 클래스를 구현한다.