### PR TITLE
Fix: add working-directory

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,9 +30,6 @@ jobs:
         
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-      
-    - name: Test
-      run: ./gradlew test
-      
-    - name: Build with Gradle
-      run: ./gradlew build
+
+    - name: Test and Build with Gradle
+      run: ./gradlew clean build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,6 +13,9 @@ jobs:
   backend_ci:
 
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: i-like-this-page-backend
 
     steps:
     - name: Checkout


### PR DESCRIPTION
### 에러
`chmod: cannot access 'gradlew': No such file or directory`

### 해결방안
gradlew를 찾을 수 없다고 하길래, 현재 프로젝트가 backend, frontend 2개로 나눠져있어서 생긴 에러라 생각된다.
workflow에서 working-directory를 설정해주어야 한다고 생각한다.