### PR TITLE
Fix: rename HomeController to InfoRestController

### DIFF
--- a/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/InfoRestController.java
+++ b/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/InfoRestController.java
@@ -17,7 +17,7 @@ public class InfoRestController {
 	@GetMapping("/version")
 	public ApiResult<String> version() {
 		return ApiResult.success(
-				"I LIKE THIS PAGE - " + buildProperties.getVersion()
+				"The version of i-like-this-page is " + buildProperties.getVersion()
 		);
 	}
 }

--- a/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/InfoRestController.java
+++ b/i-like-this-page-backend/src/main/java/com/minhojang/ilikethispagebackend/api/InfoRestController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @CrossOrigin
 @Slf4j
-public class HomeController {
+public class InfoRestController {
 	@Autowired
 	private BuildProperties buildProperties;
 


### PR DESCRIPTION
`HomeController`에는 `GET /version`이 있는데 이는 클래스명과 맞지 않다고 생각하여, 클래스명을 `InfoRestController`로 변경한다.