### PR TITLE
Use constructor injection instead of field injection

### DIFF
--- a/i-like-this-page-backend/src/main/java/link/iltp/api/InfoController.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/InfoController.java
@@ -11,8 +11,12 @@ import org.springframework.web.bind.annotation.RestController;
 @CrossOrigin
 @Slf4j
 public class InfoController {
-	@Autowired
-	private BuildProperties buildProperties;
+
+	private final BuildProperties buildProperties;
+
+	public InfoController(BuildProperties buildProperties) {
+		this.buildProperties = buildProperties;
+	}
 
 	@GetMapping("/version")
 	public ApiResult<String> version() {

--- a/i-like-this-page-backend/src/main/java/link/iltp/api/LikeController.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/LikeController.java
@@ -13,8 +13,11 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class LikeController {
 
-	@Autowired
-	LikeService likeService;
+	private final LikeService likeService;
+
+	public LikeController(LikeService likeService) {
+		this.likeService = likeService;
+	}
 
 	@GetMapping("")
 	public ApiResult<LikeResponseDto> getLike(LikeRequestDto param) {

--- a/i-like-this-page-backend/src/main/java/link/iltp/api/TokenController.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/TokenController.java
@@ -14,8 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class TokenController {
 
-	@Autowired
-	TokenService tokenService;
+	private final TokenService tokenService;
+
+	public TokenController(TokenService tokenService) {
+		this.tokenService = tokenService;
+	}
 
 	@GetMapping("")
 	public ApiResult<String> getToken() {

--- a/i-like-this-page-backend/src/main/java/link/iltp/service/LikeService.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/service/LikeService.java
@@ -12,8 +12,12 @@ import java.util.List;
 @Service
 public class LikeService {
 
+	private final LikeRepository likeRepository;
+
 	@Autowired
-	private LikeRepository likeRepository;
+	public LikeService(LikeRepository likeRepository) {
+		this.likeRepository = likeRepository;
+	}
 
 	public Long countLikeOf(String url) {
 		return likeRepository.countByUrl(url);


### PR DESCRIPTION
> Reference #61 

필드 주입보다 생성자 주입을 사용해야 한다. 단일 생성자인 경우 `@Autowired`를 삭제할 수 있다.

### 생성자 주입(constructor injection)의 장점

- 해당 객체를 `final`로 선언 가능 = 해당 객체는 변경이 불가능한 immutable 상태 유지
- DI 컨테이너와의 결합성 제거 = DI 없이 인스턴스화 가능 = 단위 테스트 가능
  - 필드 주입은 Spring 컨테이너가 반드시 필요하다.
- 순환 참조 방지