### PR TITLE
Integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Continuous Integration
+name: CI
 
 on: pull_request
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,8 @@ name: CI
 on: pull_request
 
 jobs:
-  frontend_ci:
+  fe-ci-and-be-ci:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: i-like-this-page-frontend
 
     steps:
       - name: Checkout
@@ -23,21 +20,11 @@ jobs:
 
       - name: Install npm packages
         run: npm install
+        working-directory: i-like-this-page-frontend
 
       - name: Build frontend and Copy to backend resources
         run: npm run deploy
-
-  backend_ci:
-    needs: frontend_ci
-
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: i-like-this-page-backend
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        working-directory: i-like-this-page-frontend
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -48,6 +35,8 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+        working-directory: i-like-this-page-backend
 
       - name: Build with Gradle
         run: ./gradlew build
+        working-directory: i-like-this-page-backend

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,11 +8,8 @@ on:
     branches: [develop]
 
 jobs:
-  frontend_ci:
+  fe-ci-and-be-cicd:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: i-like-this-page-frontend
 
     steps:
       - name: Checkout
@@ -25,21 +22,11 @@ jobs:
 
       - name: Install npm packages
         run: npm install
+        working-directory: i-like-this-page-frontend
 
       - name: Build frontend and Copy to backend resources
         run: npm run deploy
-
-  backend_cicd:
-    needs: frontend_ci
-
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: i-like-this-page-backend
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+        working-directory: i-like-this-page-frontend
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -50,6 +37,7 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+        working-directory: i-like-this-page-backend
 
       - name: Copy production configuration from S3
         env:
@@ -60,12 +48,15 @@ jobs:
           --region ap-northeast-2 \
           --acl private \
           s3://iltp-deploy-bucket/application.yml src/main/resources/
+        working-directory: i-like-this-page-backend
 
       - name: Test and Build with Gradle
         run: ./gradlew clean build
+        working-directory: i-like-this-page-backend
 
       - name: Zip entire project directory
         run: zip -r iltp-backend *
+        working-directory: i-like-this-page-backend
 
       - name: Deliver to AWS S3
         env:
@@ -76,6 +67,7 @@ jobs:
           --region ap-northeast-2 \
           --acl private \
           iltp-backend.zip s3://iltp-deploy-bucket/
+        working-directory: i-like-this-page-backend
 
       - name: Deploy
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: Continuous Integration and Continuous Delivery
+name: CI/CD
 
 on:
   push:

--- a/i-like-this-page-backend/build.gradle
+++ b/i-like-this-page-backend/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.h2database:h2'
     implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'
 
@@ -30,7 +31,7 @@ dependencies {
     // https://mvnrepository.com/artifact/com.google.guava/guava
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
 
-    annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/i-like-this-page-backend/build.gradle
+++ b/i-like-this-page-backend/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.h2database:h2'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'
 

--- a/i-like-this-page-backend/src/main/java/link/iltp/api/LikeController.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/LikeController.java
@@ -20,7 +20,7 @@ public class LikeController {
 
 	@GetMapping("")
 	public ApiResult<LikeResponseDto> getLike(LikeRequestDto param) {
-		log.info("Get 'like' count of url and Get 'like' status of user with this ip address: " + param);
+		log.info("Get LIKE: " + param);
 		return ApiResult.success(
 				likeService.getLike(param.getUrl(), param.getUuid())
 		);
@@ -28,7 +28,7 @@ public class LikeController {
 
 	@PostMapping("")
 	public ApiResult<LikeResponseDto> addLike(LikeRequestDto param) {
-		log.info("Add 'like' to this url for this ip address: " + param);
+		log.info("Add LIKE: " + param);
 		return ApiResult.success(
 				likeService.saveLike(param.getUrl(), param.getUuid())
 		);
@@ -36,7 +36,7 @@ public class LikeController {
 
 	@DeleteMapping("")
 	public ApiResult<LikeResponseDto> cancelLike(LikeRequestDto param) {
-		log.info("Cancel 'like' to this url for this ip address: " + param);
+		log.info("Cancel LIKE: " + param);
 		return ApiResult.success(
 				likeService.deleteLike(param.getUrl(), param.getUuid())
 		);

--- a/i-like-this-page-backend/src/main/java/link/iltp/api/TokenController.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/TokenController.java
@@ -21,7 +21,7 @@ public class TokenController {
 
 	@GetMapping("")
 	public ApiResult<String> getToken() {
-		log.info("Get new token");
+		log.info("Get new TOKEN");
 		return ApiResult.success(
 				jwtTokenProvider.generateNewToken()
 		);

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario1.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario1.java
@@ -1,17 +1,11 @@
 package link.iltp.integration;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import link.iltp.api.ApiResult;
 import link.iltp.common.dto.LikeResponseDto;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class Scenario1 extends ScenarioBase {
 	private static final String TEST_URL = "localhost/test/1/";
@@ -29,89 +23,42 @@ public class Scenario1 extends ScenarioBase {
 		printDescription(SCENE_0);
 
 		printDescription(SCENE_1);
-		getNewToken();
+		getNewTokenForIltp();
 
 		printDescription(SCENE_2);
-		getLikeOf(TEST_URL);
+		getLikeOfUrl();
 
 		printDescription(SCENE_3);
-		likeThis(TEST_URL);
+		likeThisUrl();
 
 		printDescription(SCENE_4);
-		unlikeThis(TEST_URL);
+		unlikeThisUrl();
 
 		printDescription(SCENE_END);
 	}
 
-	private void getNewToken() throws Exception {
-		ResultActions action = mockMvc.perform(get("/api/v1/token"));
-		MvcResult result = action
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andReturn();
-		String body = result.getResponse().getContentAsString();
-
-		ApiResult<String> apiResult = convertJsonStringToObject(body, new TypeReference<ApiResult<String>>() {
-		});
-		String newToken = apiResult.getResponse();
-
-		token = JWT_AUTH_PREFIX + newToken;
-		assertThat(token, is(not(emptyString())));
+	private void getNewTokenForIltp() throws Exception {
+		token = GET_token();
 	}
 
-	private void getLikeOf(final String url) throws Exception {
-		ResultActions action = mockMvc.perform(get("/api/v1/like")
-				.param("url", url)
-				.header("Authorization", token));
-		MvcResult result = action
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andReturn();
-		String body = result.getResponse().getContentAsString();
-
-		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
-		});
-
-		LikeResponseDto likeResponseDto = apiResult.getResponse();
+	private void getLikeOfUrl() throws Exception {
+		LikeResponseDto likeResponseDto = GET_like(TEST_URL, token);
 
 		assertThat(likeResponseDto, is(notNullValue()));
 		assertThat(likeResponseDto.isLikeStatus(), is(false));
 		assertThat(likeResponseDto.getLikeCount(), is(3L));
 	}
 
-	private void likeThis(final String url) throws Exception {
-		ResultActions action = mockMvc.perform(post("/api/v1/like")
-				.param("url", url)
-				.header("Authorization", token));
-
-		MvcResult result = action.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andReturn();
-		String body = result.getResponse().getContentAsString();
-		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
-		});
-
-		LikeResponseDto likeResponseDto = apiResult.getResponse();
+	private void likeThisUrl() throws Exception {
+		LikeResponseDto likeResponseDto = POST_like(TEST_URL, token);
 
 		assertThat(likeResponseDto, is(notNullValue()));
 		assertThat(likeResponseDto.isLikeStatus(), is(true));
 		assertThat(likeResponseDto.getLikeCount(), is(4L));
 	}
 
-	private void unlikeThis(final String url) throws Exception {
-		ResultActions action = mockMvc.perform(delete("/api/v1/like")
-				.param("url", url)
-				.header("Authorization", token));
-
-		MvcResult result = action.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andReturn();
-
-		String body = result.getResponse().getContentAsString();
-		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
-		});
-
-		LikeResponseDto likeResponseDto = apiResult.getResponse();
+	private void unlikeThisUrl() throws Exception {
+		LikeResponseDto likeResponseDto = DELETE_like(TEST_URL, token);
 
 		assertThat(likeResponseDto, is(notNullValue()));
 		assertThat(likeResponseDto.isLikeStatus(), is(false));

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario1.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario1.java
@@ -1,0 +1,120 @@
+package link.iltp.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import link.iltp.api.ApiResult;
+import link.iltp.common.dto.LikeResponseDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class Scenario1 extends ScenarioBase {
+	private static final String TEST_URL = "localhost/test/1/";
+	private static final String SCENE_0 = "0. URL [" + TEST_URL + "]은 현재 3개의 좋아요를 가지고 있다. 사용자는 iltp 위젯을 사용하는 페이지에 들어가 본 적이 없다.";
+	private static final String SCENE_1 = "1. URL [" + TEST_URL + "]에 처음 접근하는 사용자는 로컬 스토리지에 토큰(iltp_tk)이 없다. 프론트엔드에서 토큰을 요청한다.";
+	private static final String SCENE_2 = "2. URL [" + TEST_URL + "]의 좋아요 개수를 가져온다.";
+	private static final String SCENE_3 = "3. URL [" + TEST_URL + "] iltp 위젯의 좋아요 버튼을 누른다.";
+	private static final String SCENE_4 = "4. URL [" + TEST_URL + "] iltp 위젯의 좋아요 버튼을 다시 누른다. 좋아요가 취소된다.";
+	private static final String SCENE_END = "시나리오 #1 끝.";
+
+	private static String token = "";
+
+	@Test
+	public void scenario_1() throws Exception {
+		printDescription(SCENE_0);
+
+		printDescription(SCENE_1);
+		getNewToken();
+
+		printDescription(SCENE_2);
+		getLikeOf(TEST_URL);
+
+		printDescription(SCENE_3);
+		likeThis(TEST_URL);
+
+		printDescription(SCENE_4);
+		unlikeThis(TEST_URL);
+
+		printDescription(SCENE_END);
+	}
+
+	private void getNewToken() throws Exception {
+		ResultActions action = mockMvc.perform(get("/api/v1/token"));
+		MvcResult result = action
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andReturn();
+		String body = result.getResponse().getContentAsString();
+
+		ApiResult<String> apiResult = convertJsonStringToObject(body, new TypeReference<ApiResult<String>>() {
+		});
+		String newToken = apiResult.getResponse();
+
+		token = JWT_AUTH_PREFIX + newToken;
+		assertThat(token, is(not(emptyString())));
+	}
+
+	private void getLikeOf(final String url) throws Exception {
+		ResultActions action = mockMvc.perform(get("/api/v1/like")
+				.param("url", url)
+				.header("Authorization", token));
+		MvcResult result = action
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andReturn();
+		String body = result.getResponse().getContentAsString();
+
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
+		});
+
+		LikeResponseDto likeResponseDto = apiResult.getResponse();
+
+		assertThat(likeResponseDto, is(notNullValue()));
+		assertThat(likeResponseDto.isLikeStatus(), is(false));
+		assertThat(likeResponseDto.getLikeCount(), is(3L));
+	}
+
+	private void likeThis(final String url) throws Exception {
+		ResultActions action = mockMvc.perform(post("/api/v1/like")
+				.param("url", url)
+				.header("Authorization", token));
+
+		MvcResult result = action.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andReturn();
+		String body = result.getResponse().getContentAsString();
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
+		});
+
+		LikeResponseDto likeResponseDto = apiResult.getResponse();
+
+		assertThat(likeResponseDto, is(notNullValue()));
+		assertThat(likeResponseDto.isLikeStatus(), is(true));
+		assertThat(likeResponseDto.getLikeCount(), is(4L));
+	}
+
+	private void unlikeThis(final String url) throws Exception {
+		ResultActions action = mockMvc.perform(delete("/api/v1/like")
+				.param("url", url)
+				.header("Authorization", token));
+
+		MvcResult result = action.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andReturn();
+
+		String body = result.getResponse().getContentAsString();
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
+		});
+
+		LikeResponseDto likeResponseDto = apiResult.getResponse();
+
+		assertThat(likeResponseDto, is(notNullValue()));
+		assertThat(likeResponseDto.isLikeStatus(), is(false));
+		assertThat(likeResponseDto.getLikeCount(), is(3L));
+	}
+}

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario1.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario1.java
@@ -12,8 +12,8 @@ public class Scenario1 extends ScenarioBase {
 	private static final String SCENE_0 = "0. URL [" + TEST_URL + "]은 현재 3개의 좋아요를 가지고 있다. 사용자는 iltp 위젯을 사용하는 페이지에 들어가 본 적이 없다.";
 	private static final String SCENE_1 = "1. URL [" + TEST_URL + "]에 처음 접근하는 사용자는 로컬 스토리지에 토큰(iltp_tk)이 없다. 프론트엔드에서 토큰을 요청한다.";
 	private static final String SCENE_2 = "2. URL [" + TEST_URL + "]의 좋아요 개수를 가져온다.";
-	private static final String SCENE_3 = "3. URL [" + TEST_URL + "] iltp 위젯의 좋아요 버튼을 누른다.";
-	private static final String SCENE_4 = "4. URL [" + TEST_URL + "] iltp 위젯의 좋아요 버튼을 다시 누른다. 좋아요가 취소된다.";
+	private static final String SCENE_3 = "3. URL [" + TEST_URL + "]의 좋아요 버튼을 누른다.";
+	private static final String SCENE_4 = "4. URL [" + TEST_URL + "]의 좋아요 버튼을 다시 누른다. 좋아요가 취소된다.";
 	private static final String SCENE_END = "시나리오 #1 끝.";
 
 	private static String token = "";

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario2.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario2.java
@@ -1,0 +1,85 @@
+package link.iltp.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import link.iltp.api.ApiResult;
+import link.iltp.common.dto.LikeResponseDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class Scenario2 extends ScenarioBase {
+	private static final String TEST_URL = "localhost/test/1/";
+	private static final String SCENE_0 = "0. 사용자는 이미 좋아요를 누른 적 있는 URL [" + TEST_URL + "]로 들어간다. 이미 iltp 위젯을 사용한 적 있기 때문에 로컬 스토리지에 토큰(iltp_tk)가 존재한다.";
+	private static final String SCENE_1 = "1. URL [" + TEST_URL + "]의 좋아요 개수를 가져온다.";
+	private static final String SCENE_2 = "2. URL [" + TEST_URL + "]의 좋아요를 누른다. 좋아요가 취소된다.";
+	private static final String SCENE_END = "시나리오 #2 끝.";
+
+	private static final String TEST_UUID = "00000000-0000-0000-0000-000000000000";
+	private static String token = "";
+
+	@Test
+	public void scenario_2() throws Exception {
+		printDescription(SCENE_0);
+		init();
+
+		printDescription(SCENE_1);
+		getLikeOf(TEST_URL);
+
+		printDescription(SCENE_2);
+		unlikeThis(TEST_URL);
+
+		printDescription(SCENE_END);
+	}
+
+	private void init() {
+		token = JWT_AUTH_PREFIX + jwtTokenProvider.generateToken(TEST_UUID);
+	}
+
+	private void getLikeOf(final String url) throws Exception {
+		ResultActions action = mockMvc.perform(get("/api/v1/like")
+				.param("url", url)
+				.header("Authorization", token));
+		MvcResult result = action
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andReturn();
+		String body = result.getResponse().getContentAsString();
+
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
+		});
+
+		LikeResponseDto likeResponseDto = apiResult.getResponse();
+
+		assertThat(likeResponseDto, is(notNullValue()));
+		assertThat(likeResponseDto.isLikeStatus(), is(true));
+		assertThat(likeResponseDto.getLikeCount(), is(3L));
+	}
+
+	private void unlikeThis(final String url) throws Exception {
+		ResultActions action = mockMvc.perform(delete("/api/v1/like")
+				.param("url", url)
+				.header("Authorization", token));
+
+		MvcResult result = action.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andReturn();
+
+		String body = result.getResponse().getContentAsString();
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
+		});
+
+		LikeResponseDto likeResponseDto = apiResult.getResponse();
+
+		assertThat(likeResponseDto, is(notNullValue()));
+		assertThat(likeResponseDto.isLikeStatus(), is(false));
+		assertThat(likeResponseDto.getLikeCount(), is(2L));
+	}
+}

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario2.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario2.java
@@ -1,19 +1,11 @@
 package link.iltp.integration;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import link.iltp.api.ApiResult;
 import link.iltp.common.dto.LikeResponseDto;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class Scenario2 extends ScenarioBase {
 	private static final String TEST_URL = "localhost/test/1/";
@@ -31,10 +23,10 @@ public class Scenario2 extends ScenarioBase {
 		init();
 
 		printDescription(SCENE_1);
-		getLikeOf(TEST_URL);
+		getLikeOfUrl();
 
 		printDescription(SCENE_2);
-		unlikeThis(TEST_URL);
+		unlikeThis();
 
 		printDescription(SCENE_END);
 	}
@@ -43,40 +35,16 @@ public class Scenario2 extends ScenarioBase {
 		token = JWT_AUTH_PREFIX + jwtTokenProvider.generateToken(TEST_UUID);
 	}
 
-	private void getLikeOf(final String url) throws Exception {
-		ResultActions action = mockMvc.perform(get("/api/v1/like")
-				.param("url", url)
-				.header("Authorization", token));
-		MvcResult result = action
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andReturn();
-		String body = result.getResponse().getContentAsString();
-
-		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
-		});
-
-		LikeResponseDto likeResponseDto = apiResult.getResponse();
+	private void getLikeOfUrl() throws Exception {
+		LikeResponseDto likeResponseDto = GET_like(TEST_URL, token);
 
 		assertThat(likeResponseDto, is(notNullValue()));
 		assertThat(likeResponseDto.isLikeStatus(), is(true));
 		assertThat(likeResponseDto.getLikeCount(), is(3L));
 	}
 
-	private void unlikeThis(final String url) throws Exception {
-		ResultActions action = mockMvc.perform(delete("/api/v1/like")
-				.param("url", url)
-				.header("Authorization", token));
-
-		MvcResult result = action.andExpect(status().isOk())
-				.andExpect(jsonPath("$.success").value(true))
-				.andReturn();
-
-		String body = result.getResponse().getContentAsString();
-		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
-		});
-
-		LikeResponseDto likeResponseDto = apiResult.getResponse();
+	private void unlikeThis() throws Exception {
+		LikeResponseDto likeResponseDto = DELETE_like(TEST_URL, token);
 
 		assertThat(likeResponseDto, is(notNullValue()));
 		assertThat(likeResponseDto.isLikeStatus(), is(false));

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario3.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario3.java
@@ -1,0 +1,167 @@
+package link.iltp.integration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import link.iltp.api.ApiResult;
+import link.iltp.common.dto.LikeResponseDto;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class Scenario3 extends ScenarioBase {
+	private static final int THREAD_POOL_SIZE = 10;
+	private static final int USER_NUM = 100;
+	private static final String TEST_URL = "localhost/test/1/";
+	private static final String SCENE_0 = "0. " + USER_NUM + "명이 동시에 URL [" + TEST_URL + "]에 접속하려고 한다.";
+	private static final String SCENE_1 = "1. " + USER_NUM + "명이 동시에 URL [" + TEST_URL + "]의 좋아요 개수를 가져온다.";
+	private static final String SCENE_2 = "2. " + USER_NUM + "명이 동시에 URL [" + TEST_URL + "]의 좋아요를 추가한 후 취소한다.";
+	private static final String SCENE_3 = "3. URL [" + TEST_URL + "]의 좋아요 개수가 초기값과 같은지 확인한다.";
+	private static final String SCENE_END = "시나리오 #3 끝.";
+
+	@RepeatedTest(3)
+	public void scenario_3() throws Exception {
+		printDescription(SCENE_0);
+		init();
+
+		printDescription(SCENE_1);
+		concurrentlyGetLikeOf();
+
+		printDescription(SCENE_2);
+		concurrentlyAddLikeAndCancelLike();
+
+		printDescription(SCENE_3);
+		checkEqualToInitValue();
+
+		printDescription(SCENE_END);
+	}
+
+	private List<User> users;
+	private long initialLikeCount;
+
+	private void init() throws Exception {
+		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+		users = new ArrayList<>();
+
+		for (int i = 0; i < USER_NUM; i++) {
+			final String newToken = JWT_AUTH_PREFIX + jwtTokenProvider.generateNewToken();
+			User user = new User(executorService, mockMvc, newToken);
+			users.add(user);
+		}
+
+		initialLikeCount = getLikeCount();
+	}
+
+	private long getLikeCount() throws Exception {
+		ResultActions action = mockMvc.perform(
+				get("/api/v1/like")
+						.param("url", TEST_URL)
+						.header("Authorization", JWT_AUTH_PREFIX + jwtTokenProvider.generateNewToken()));
+		final MvcResult result = action
+				.andExpect(status().isOk())
+				.andReturn();
+
+		final String body = result.getResponse().getContentAsString();
+		final ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(body, new TypeReference<>() {
+		});
+
+		long likeCount = apiResult.getResponse().getLikeCount();
+		printDescription("getLikeCount() = " + likeCount);
+		return likeCount;
+	}
+
+	private void concurrentlyGetLikeOf() {
+		final List<CompletableFuture<MvcResult>> futures = users.parallelStream()
+				.map(u -> u.callGetLikeAsync(TEST_URL))
+				.collect(Collectors.toList());
+
+		final CompletableFuture<Void> allFuture = CompletableFuture
+				.allOf(futures.toArray(CompletableFuture[]::new))
+				.exceptionally(e -> {
+					throw new RuntimeException("Failed to call get like of " + TEST_URL + " concurrently");
+				});
+
+		allFuture.join();
+	}
+
+	private void concurrentlyAddLikeAndCancelLike() {
+		final List<CompletableFuture<Void>> futures = users.stream()
+				.map(u -> u.callAddLikeThenCancelLike(TEST_URL))
+				.collect(Collectors.toList());
+
+		final CompletableFuture<Void> allFuture = CompletableFuture
+				.allOf(futures.toArray(CompletableFuture[]::new))
+				.exceptionally(e -> {
+					throw new RuntimeException("Failed to call add and cancel like of " + TEST_URL + " concurrently");
+				});
+
+		allFuture.join();
+	}
+
+	private void checkEqualToInitValue() throws Exception {
+		long nowLikeCount = getLikeCount();
+		assertThat(nowLikeCount, is(equalTo(initialLikeCount)));
+	}
+
+	static class User {
+		private final ExecutorService executorService;
+		private final MockMvc mockMvc;
+		private final String token;
+
+		User(ExecutorService executorService, MockMvc mockMvc, String token) {
+			this.executorService = executorService;
+			this.mockMvc = mockMvc;
+			this.token = token;
+		}
+
+		public CompletableFuture<MvcResult> callGetLikeAsync(String url) {
+			return CompletableFuture.supplyAsync(() -> {
+						try {
+							ResultActions action = mockMvc.perform(get("/api/v1/like")
+									.param("url", url)
+									.header("Authorization", token));
+							return action.andExpect(status().isOk()).andReturn();
+						} catch (Exception e) {
+							throw new RuntimeException("Something wrong with calling GET /api/v1/like");
+						}
+					}, executorService)
+					.exceptionally(e -> {
+						throw new RuntimeException("Failed to get like of " + url, e);
+					});
+		}
+
+		public CompletableFuture<Void> callAddLikeThenCancelLike(String url) {
+			return CompletableFuture.runAsync(() -> {
+						try {
+							ResultActions addAction = mockMvc.perform(post("/api/v1/like")
+									.param("url", url)
+									.header("Authorization", token));
+							addAction.andExpect(status().isOk());
+
+							ResultActions cancelAction = mockMvc.perform(delete("/api/v1/like")
+									.param("url", url)
+									.header("Authorization", token));
+							cancelAction.andExpect(status().isOk());
+						} catch (Exception e) {
+							throw new RuntimeException("Something wrong with calling POST and DELETE /api/v1/like");
+						}
+					}, executorService)
+					.exceptionally(e -> {
+						throw new RuntimeException("Failed to add and cancel like of " + url, e);
+					});
+		}
+	}
+}

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario4.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario4.java
@@ -1,0 +1,27 @@
+package link.iltp.integration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class Scenario4 extends ScenarioBase {
+	private static final String SCENE_1 = "프론트엔드를 번들링한 자바스크립트 파일이 있는지 확인한다.";
+	private static final String SCENE_END = "시나리오 #4 끝.";
+
+	@Test
+	public void scenario_4() throws Exception {
+		printDescription(SCENE_1);
+		checkIltpBundleJs();
+
+		printDescription(SCENE_END);
+	}
+
+	private void checkIltpBundleJs() throws Exception {
+		mockMvc.perform(get("/bundle/iltp.bundle.min.js"))
+				.andExpect(status().isOk())
+				.andExpect(header().stringValues("Content-Type", contains("application/javascript")));
+	}
+}

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/ScenarioBase.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/ScenarioBase.java
@@ -3,12 +3,21 @@ package link.iltp.integration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import link.iltp.api.ApiResult;
+import link.iltp.common.dto.LikeResponseDto;
 import link.iltp.common.util.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -17,25 +26,92 @@ public class ScenarioBase {
 	protected static final String JWT_AUTH_PREFIX = "Bearer ";
 
 	@Autowired
-	protected MockMvc mockMvc;
-
-	@Autowired
 	protected JwtTokenProvider jwtTokenProvider;
 
 	@Autowired
-	protected ObjectMapper objectMapper;
+	protected MockMvc mockMvc;
 
-	protected <T> T convertJsonStringToObject(String jsonString, TypeReference<T> typeReference) {
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	public <T> T convertJsonStringToObject(String jsonString, TypeReference<T> typeReference) {
 		try {
 			return objectMapper.readValue(jsonString, typeReference);
 		} catch (JsonProcessingException e) {
-			throw new IllegalArgumentException("Something wrong with reading the json string.");
+			throw new IllegalArgumentException("Something wrong with reading the json string.", e);
 		}
 	}
 
-	protected void printDescription(String description) {
+	public void printDescription(String description) {
 		System.out.println();
 		System.out.println(">> " + description);
 		System.out.println();
 	}
+
+	public String GET_token() throws Exception {
+		MvcResult mvcResult = mockMvc.perform(get("/api/v1/token"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.response").exists())
+				.andReturn();
+
+		String content = mvcResult.getResponse().getContentAsString();
+		ApiResult<String> apiResult = convertJsonStringToObject(content, new TypeReference<>() {
+		});
+
+		assertThat(apiResult.getResponse(), is(not(emptyString())));
+		return JWT_AUTH_PREFIX + apiResult.getResponse();
+	}
+
+	public LikeResponseDto GET_like(final String url, final String token) throws Exception {
+		MvcResult mvcResult = mockMvc.perform(get("/api/v1/like")
+						.param("url", url)
+						.header("Authorization", token))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.response").exists())
+				.andReturn();
+
+		String content = mvcResult.getResponse().getContentAsString();
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(content, new TypeReference<>() {
+		});
+
+		assertThat(apiResult.getResponse(), is(notNullValue()));
+		return apiResult.getResponse();
+	}
+
+	public LikeResponseDto POST_like(final String url, final String token) throws Exception {
+		MvcResult mvcResult = mockMvc.perform(post("/api/v1/like")
+						.param("url", url)
+						.header("Authorization", token))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.response").exists())
+				.andReturn();
+
+		String content = mvcResult.getResponse().getContentAsString();
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(content, new TypeReference<>() {
+		});
+
+		assertThat(apiResult.getResponse(), is(notNullValue()));
+		return apiResult.getResponse();
+	}
+
+	public LikeResponseDto DELETE_like(final String url, final String token) throws Exception {
+		MvcResult mvcResult = mockMvc.perform(delete("/api/v1/like")
+						.param("url", url)
+						.header("Authorization", token))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.response").exists())
+				.andReturn();
+
+		String content = mvcResult.getResponse().getContentAsString();
+		ApiResult<LikeResponseDto> apiResult = convertJsonStringToObject(content, new TypeReference<>() {
+		});
+
+		assertThat(apiResult.getResponse(), is(notNullValue()));
+		return apiResult.getResponse();
+	}
+
 }

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/ScenarioBase.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/ScenarioBase.java
@@ -1,0 +1,41 @@
+package link.iltp.integration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import link.iltp.common.util.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ScenarioBase {
+	protected static final String JWT_AUTH_PREFIX = "Bearer ";
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	protected <T> T convertJsonStringToObject(String jsonString, TypeReference<T> typeReference) {
+		try {
+			return objectMapper.readValue(jsonString, typeReference);
+		} catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Something wrong with reading the json string.");
+		}
+	}
+
+	protected void printDescription(String description) {
+		System.out.println();
+		System.out.println(">> " + description);
+		System.out.println();
+	}
+}

--- a/i-like-this-page-backend/src/test/resources/application.yml
+++ b/i-like-this-page-backend/src/test/resources/application.yml
@@ -10,10 +10,6 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create-drop
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
     defer-datasource-initialization: true
   jwt:
     issuer: i-like-this-page


### PR DESCRIPTION
> Closes #71 

통합 테스트 시나리오를 정하고 그대로 실행하는 코드를 구현했다.

### 시나리오 1
0. 어떤 URL은 현재 3개의 좋아요를 가지고 있다. 사용자는 iltp 위젯을 사용하는 페이지에 들어가 본 적이 없다.
1. 어떤 URL에 처음 접근하는 사용자는 로컬 스토리지에 토큰(iltp_tk)이 없다. 프론트엔드에서 토큰을 요청한다.
2. 어떤 URL의 좋아요 개수를 가져온다.
3. 어떤 URL의 좋아요 버튼을 누른다.
4. 어떤 URL의 좋아요 버튼을 다시 누른다. 좋아요가 취소된다.

### 시나리오 2
0. 사용자는 이미 좋아요를 누른 적 있는 어떤 URL로 들어간다. 이미 iltp 위젯을 사용한 적 있기 때문에 로컬 스토리지에 토큰(iltp_tk)가 존재한다.
1. 어떤 URL의 좋아요 개수를 가져온다.
2. 어떤 URL의 좋아요를 누른다. 좋아요가 취소된다.

### 시나리오 3
0. 100명이 동시에 어떤 URL에 접속하려고 한다.
1. 100명이 동시에 어떤 URL의 좋아요 개수를 가져온다.
2. 100명이 동시에 어떤 URL의 좋아요를 추가한 후 취소한다.