### PR TITLE
Use ObjectMapper in test

### DIFF
--- a/i-like-this-page-backend/src/main/java/link/iltp/api/ApiResult.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/ApiResult.java
@@ -1,17 +1,16 @@
 package link.iltp.api;
 
+import lombok.*;
 import org.springframework.http.HttpStatus;
 
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Setter
 public class ApiResult<T> {
-	private final boolean success;
-	private final T response;
-	private final ApiError error;
-
-	private ApiResult(boolean success, T response, ApiError error) {
-		this.success = success;
-		this.response = response;
-		this.error = error;
-	}
+	private boolean success;
+	private T response;
+	private ApiError error;
 
 	public static <T> ApiResult<T> success(T response) {
 		return new ApiResult<>(true, response, null);
@@ -23,17 +22,5 @@ public class ApiResult<T> {
 
 	public static ApiResult<?> error(String message, HttpStatus status) {
 		return new ApiResult<>(false, null, new ApiError(message, status));
-	}
-
-	public boolean isSuccess() {
-		return success;
-	}
-
-	public T getResponse() {
-		return response;
-	}
-
-	public ApiError getError() {
-		return error;
 	}
 }

--- a/i-like-this-page-backend/src/main/java/link/iltp/common/dto/LikeRequestDto.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/common/dto/LikeRequestDto.java
@@ -3,8 +3,10 @@ package link.iltp.common.dto;
 import lombok.*;
 
 @AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Setter
+@Builder
 @ToString
 public class LikeRequestDto {
 	private String url;

--- a/i-like-this-page-backend/src/main/java/link/iltp/common/dto/LikeResponseDto.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/common/dto/LikeResponseDto.java
@@ -3,8 +3,10 @@ package link.iltp.common.dto;
 import lombok.*;
 
 @AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@Setter
+@Builder
 @ToString
 public class LikeResponseDto {
 	private String url;

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/ScenarioBase.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/ScenarioBase.java
@@ -8,6 +8,7 @@ import link.iltp.common.util.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,8 +31,7 @@ public class ScenarioBase {
 	@Autowired
 	protected MockMvc mockMvc;
 
-	@Autowired
-	private ObjectMapper objectMapper;
+	private final ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
 	public <T> ApiResult<T> convertJsonStringToApiResult(String jsonString, Class<T> responseType) {
 		try {


### PR DESCRIPTION
> Closes #74 

Jackson 라이브러리의 `ObjectMapper`는 json을 다룰 때 필요한 객체이다.

Spring에서 json 메시지를 변환하기 위해 `MappingJackson2HttpMessageConverter`에서 사용한다.
`JacksonAutoConfiguration`에 의해서 `ObjectMapper`는 빈으로 등록된다.

### 문제

기존에 테스트 환경에서, 이를 `@Autowired`로 주입받아서 사용했다.
그럴 필요가 없다는 것을 느끼고 직접 `new`로 생성하여 테스트하려 했으나 에러가 발생했다.

### 과정

객체의 기본 생성자가 없기에 발생한 에러였다.
기본 생성자를 생성하여 해결할 수 있으나, 왜 주입받았을 때는 이게 필요가 없는지 살펴봤다.

디버깅 결과, 주입받은 `ObjectMapper`는 `PropertyBasedCreator`라는 필드를 가지고 있었고, 직접 생성한 `ObjectMapper`는 이 필드가 `null`이었다. 이 필드에 의해 분기된 이후에 기본 생성자를 확인하면서 에러를 뿜었다.

더 파고들어봐야 알겠지만, Spring에서 `ObjectMapper`는 Builder에 의해서 생성되는데 이 때 적용되는 config의 차이가 아닐까 짐작해본다.

### 결론

Lombok의 `@NoArgsConstructor(access = AccessLevel.PRIVATE)`를 추가한다. 
