### PR TITLE
Test coverage using Jacoco

### DIFF
--- a/i-like-this-page-backend/build.gradle
+++ b/i-like-this-page-backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.5.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'jacoco'
 }
 
 group = 'com.minho-jang'
@@ -37,6 +38,33 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacocoTestReport {
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.90
+            }
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+            excludes = [
+                    'link.iltp.Application'
+            ]
+        }
+    }
 }
 
 jar {

--- a/i-like-this-page-backend/lombok.config
+++ b/i-like-this-page-backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/i-like-this-page-backend/src/main/java/link/iltp/api/ApiError.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/ApiError.java
@@ -6,10 +6,6 @@ public class ApiError {
 	private final String message;
 	private final int status;
 
-	ApiError(Throwable throwable, HttpStatus status) {
-		this(throwable.getMessage(), status);
-	}
-
 	ApiError(String message, HttpStatus status) {
 		this.message = message;
 		this.status = status.value();

--- a/i-like-this-page-backend/src/main/java/link/iltp/api/ApiResult.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/api/ApiResult.java
@@ -17,10 +17,6 @@ public class ApiResult<T> {
 		return new ApiResult<>(true, response, null);
 	}
 
-	public static ApiResult<?> error(Throwable throwable, HttpStatus status) {
-		return new ApiResult<>(false, null, new ApiError(throwable, status));
-	}
-
 	public static ApiResult<?> error(String message, HttpStatus status) {
 		return new ApiResult<>(false, null, new ApiError(message, status));
 	}

--- a/i-like-this-page-backend/src/main/java/link/iltp/entity/Like.java
+++ b/i-like-this-page-backend/src/main/java/link/iltp/entity/Like.java
@@ -1,14 +1,13 @@
 package link.iltp.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Data
+@EqualsAndHashCode
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity(name = "likes")

--- a/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario3.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/integration/Scenario3.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class Scenario3 extends ScenarioBase {
-	private static final int THREAD_POOL_SIZE = 10;
+	private static final int THREAD_POOL_SIZE = 20;
 	private static final int USER_NUM = 100;
 	private static final String TEST_URL = "localhost/test/1/";
 	private static final String SCENE_0 = "0. " + USER_NUM + "명이 동시에 URL [" + TEST_URL + "]에 접속하려고 한다.";

--- a/i-like-this-page-backend/src/test/java/link/iltp/unit/entitytest/LikeTest.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/unit/entitytest/LikeTest.java
@@ -1,0 +1,34 @@
+package link.iltp.unit.entitytest;
+
+import link.iltp.entity.Like;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class LikeTest {
+	@Test
+	@DisplayName("Like 엔티티 동등성, 동일성 테스트")
+	public void hashcodeTest() {
+		// given
+		final Long tmpLikeId = 1L;
+		final Long tmpAnotherLikeId = 2L;
+		final String tmpUuid = "TEMP-UUID";
+		final String tmpUrl = "TEMP-URL";
+		final LocalDateTime tmpCreateAt = LocalDateTime.now();
+
+		// when
+		Like like1 = new Like(tmpLikeId, tmpUuid, tmpUrl, tmpCreateAt);
+		Like like2 = new Like(tmpLikeId, tmpUuid, tmpUrl, tmpCreateAt);
+		Like like3 = new Like(tmpAnotherLikeId, tmpUuid, tmpUrl, tmpCreateAt);
+
+		// then
+		assertThat(like1.hashCode() == like2.hashCode(), is(true));
+		assertThat(like1.hashCode() == like3.hashCode(), is(false));
+		assertThat(like1.equals(like2), is(true));
+		assertThat(like1.equals(like3), is(false));
+	}
+}

--- a/i-like-this-page-backend/src/test/java/link/iltp/unit/webmvctest/LikeRequestHandlerMethodArgumentResolverTest.java
+++ b/i-like-this-page-backend/src/test/java/link/iltp/unit/webmvctest/LikeRequestHandlerMethodArgumentResolverTest.java
@@ -34,8 +34,7 @@ public class LikeRequestHandlerMethodArgumentResolverTest {
 	@DisplayName("URL이 없을 때, POST /api/v1/like 테스트")
 	public void addLikeWithoutUrl() throws Exception {
 		// given
-		final String uuid = NORMAL_UUID;
-		final String token = JWT_AUTH_PREFIX + jwtTokenProvider.generateToken(uuid);
+		final String token = JWT_AUTH_PREFIX + jwtTokenProvider.generateToken(NORMAL_UUID);
 
 		// when
 		final ResultActions actions = mockMvc.perform(post("/api/v1/like")
@@ -51,12 +50,9 @@ public class LikeRequestHandlerMethodArgumentResolverTest {
 	@Test
 	@DisplayName("authorization이 없을 때, POST /api/v1/like 테스트")
 	public void addLikeWithoutAuth() throws Exception {
-		// given
-		final String url = NORMAL_URL;
-
 		// when
 		final ResultActions actions = mockMvc.perform(post("/api/v1/like")
-				.param("url", url));
+				.param("url", NORMAL_URL));
 
 		// then
 		actions.andExpect(status().is4xxClientError())
@@ -69,12 +65,29 @@ public class LikeRequestHandlerMethodArgumentResolverTest {
 	@DisplayName("authorization이 부적절할 때, POST /api/v1/like 테스트")
 	public void addLikeWithInvalidAuth() throws Exception {
 		// given
-		final String url = NORMAL_URL;
 		final String token = JWT_AUTH_PREFIX + "ANY_INVALID_TOKEN";
 
 		// when
 		final ResultActions actions = mockMvc.perform(post("/api/v1/like")
-				.param("url", url)
+				.param("url", NORMAL_URL)
+				.header("Authorization", token));
+
+		// then
+		actions.andExpect(status().is4xxClientError())
+				.andExpect(jsonPath("$.success").value("false"))
+				.andExpect(jsonPath("$.response").doesNotExist())
+				.andExpect(jsonPath("$.error").exists());
+	}
+
+	@Test
+	@DisplayName("authorization prefix 부적절할 때, POST /api/v1/like 테스트")
+	public void addLikeWithInvalidAuthPrefix() throws Exception {
+		// given
+		final String token = "TEMP-PREFIX" + jwtTokenProvider.generateToken(NORMAL_UUID);
+
+		// when
+		final ResultActions actions = mockMvc.perform(post("/api/v1/like")
+				.param("url", NORMAL_URL)
 				.header("Authorization", token));
 
 		// then
@@ -88,12 +101,11 @@ public class LikeRequestHandlerMethodArgumentResolverTest {
 	@DisplayName("토큰은 맞지만 UUID가 없을 때, POST /api/v1/like 테스트")
 	public void addLikeWithValidAuthNoUuid() throws Exception {
 		// given
-		final String url = NORMAL_URL;
 		final String token = JWT_AUTH_PREFIX + jwtTokenProvider.generateToken("");
 
 		// when
 		final ResultActions actions = mockMvc.perform(post("/api/v1/like")
-				.param("url", url)
+				.param("url", NORMAL_URL)
 				.header("Authorization", token));
 
 		// then


### PR DESCRIPTION
> Closes #76

Jacoco는 테스트 커버리지를 알려주는 라이브러리이다. 
빌드할 때, 테스트를 수행하고 이에 대한 커버리지를 파악하여, 일정 수준 이상의 커버리지일 때 진행하도록 한다.

롬복에 의해 생성되는 코드는 테스트할 필요 없다고 판단하여, 이에 대한 설정을 추가한다. (lombok.config)

테스트 시나리오 3의 실행 속도를 올리기 위해 쓰레드 개수를 조정했다.